### PR TITLE
Adding support for RHEL7 EPEL repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ This Ansible role installs the EPEL repository so that Yum can use it.
 Role Variables
 --------------
 
-There is one default variables for this role that can be overridden if needed:
+Default variables for this role that can be overridden if needed:
 
-    epel_url: https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+    epel_repo_url - defines the URL where the EPEL rpm file is downloaded
+
+    epel_repo_file - defines the file system path where the epel repo is configured
 
 
 Example Playbook
@@ -17,12 +19,12 @@ Example Playbook
 A simple example playbook that overrides a default variable:
 
     ---
-    
+
     - hosts: all
-    
+
     # Optionally, use a different EPEL repository location
     - epel_url: https://mirrors.kernel.org/fedora-epel/6/x86_64/epel-release-6-8.noarch.rpm
-    
+
     roles:
       - { role: uclalib_role_epel }
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 
-epel_url: https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+epel_repo_file: "/etc/yum.repos.d/epel.repo"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
 
+- name: Determine if EPEL repo is already set-up
+  stat:
+    path: "{{ epel_repo_file }}"
+  register: epel_repo_file_status
+
 - name: Add EPEL Repo
-  yum: name={{ epel_url }} state=present
+  yum:
+    name: "{{ epel_repo_url }}"
+    state: present
+  when: epel_repo_file_status.stat.exists == False


### PR DESCRIPTION
Modified the variables and tasks in this roles to support adding EPEL to either RHEL6 or RHEL7 using Ansible facts during set-up. 